### PR TITLE
Enable transparent authentication using ADFS

### DIFF
--- a/phpsaml/onelogin/saml/authrequest.php
+++ b/phpsaml/onelogin/saml/authrequest.php
@@ -34,8 +34,6 @@ class SamlAuthRequest {
             "<samlp:AuthnRequest xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" ID=\"$id\" Version=\"2.0\" IssueInstant=\"$issue_instant\" ProtocolBinding=\"urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST\" AssertionConsumerServiceURL=\"".$this->settings->assertion_consumer_service_url."\">".
             "<saml:Issuer xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">".$this->settings->issuer."</saml:Issuer>\n".
             "<samlp:NameIDPolicy xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" Format=\"".$this->settings->name_identifier_format."\" AllowCreate=\"true\"></samlp:NameIDPolicy>\n".
-            "<samlp:RequestedAuthnContext xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" Comparison=\"exact\">".
-            "<saml:AuthnContextClassRef xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">urn:federation:authentication:windows</saml:AuthnContextClassRef></samlp:RequestedAuthnContext>\n".
             "</samlp:AuthnRequest>";
 
         $deflated_request  = gzdeflate($request);

--- a/phpsaml/onelogin/saml/authrequest.php
+++ b/phpsaml/onelogin/saml/authrequest.php
@@ -35,7 +35,7 @@ class SamlAuthRequest {
             "<saml:Issuer xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">".$this->settings->issuer."</saml:Issuer>\n".
             "<samlp:NameIDPolicy xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" Format=\"".$this->settings->name_identifier_format."\" AllowCreate=\"true\"></samlp:NameIDPolicy>\n".
             "<samlp:RequestedAuthnContext xmlns:samlp=\"urn:oasis:names:tc:SAML:2.0:protocol\" Comparison=\"exact\">".
-            "<saml:AuthnContextClassRef xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef></samlp:RequestedAuthnContext>\n".
+            "<saml:AuthnContextClassRef xmlns:saml=\"urn:oasis:names:tc:SAML:2.0:assertion\">urn:federation:authentication:windows</saml:AuthnContextClassRef></samlp:RequestedAuthnContext>\n".
             "</samlp:AuthnRequest>";
 
         $deflated_request  = gzdeflate($request);


### PR DESCRIPTION
This change allows any authentication method on the ADFS side.

Previous behavior:

If a user had authenticated using a password-less method (e.g., Kerberos) to the ADFS, they would still be prompted with a password form by the ADFS server since this was explicitly requested in the SAML request.

Behavior with this patch:

Dokuwiki will accept any method accepted by the ADFS side. This enables transparent single sign on.