### PR TITLE
Updates PHP-SAML to v2.18.1 RE: CVE-2019-3465

### DIFF
--- a/phpsaml/CHANGELOG
+++ b/phpsaml/CHANGELOG
@@ -1,5 +1,47 @@
 CHANGELOG
 =========
+v.2.18.1
+* Add setSchemasPath to Auth class and fix backward compatibility
+
+v.2.18.0
+* Support rejecting unsolicited SAMLResponses.
+* Support stric destination matching.
+* Reject SAMLResponse if requestID was provided to the validotr but the InResponseTo attributeof the SAMLResponse is missing
+* Check destination against the getSelfURLNoQuery as well on LogoutRequest and LogoutResponse as we do on Response
+* Improve getSelfRoutedURLNoQuery method
+* Only add responseUrl to the settings if ResponseLocation present in the IdPMetadataParser
+* Remove use of $_GET on static method validateBinarySign
+* Fix error message when Assertion and NameId are both encrypted (not supported)
+
+v.2.17.1
+* Update xmlseclibs to 3.0.4
+* Remove Comparison atribute from RequestedAuthnContext when setting has empty value
+
+v.2.17.0
+* Set true as the default value for strict setting
+* Support 'x509cert' and 'privateKey' on signMetadata security settings
+* Relax comparision of false on SignMetadata
+* Fix CI
+
+v.2.16.0
+* Support SLO ResponseLocation
+* [#344](https://github.com/onelogin/php-saml/issues/344) Raise errors on IdPMetadataParser::parseRemoteXML and IdPMetadataParser::parseFileXML
+* Adjusted acs endpoint to extract NameQualifier and SPNameQualifier from SAMLResponse. Adjusted single logout service to provide NameQualifier and SPNameQualifier to logout method. Add getNameIdNameQualifier to Auth and SamlResponse. Extend logout method from Auth and LogoutRequest constructor to support SPNameQualifier parameter. Align LogoutRequest constructor with SAML specs
+* Add support for Subjects on AuthNRequests by the new parameter
+* Set strict=true on config examples
+
+v.2.15.0
+* Security improvement suggested by Nils Engelbertz to prevent DDOS by expansion of internally defined entities (XEE)
+* Fix bug on settings_example.php
+
+v.2.14.0
+* Add  parameter to the decryptElement method to make optional the formatting
+* [#283](https://github.com/onelogin/php-saml/pull/283) New method of importing a decrypted assertion into the XML document to replace the EncryptedAssertion. Fix signature issues on Signed Encrypted Assertions with default namespace
+* Allow the getSPMetadata() method to always include the encryption Key Descriptor
+* Change some Fatal Error to Exceptions
+* [#265](https://github.com/onelogin/php-saml/issues/265) Support parameters at getSPMetadata method
+* Avoid calling static method using this
+
 v.2.13.0
 * Update xmlseclibs with some fixes.
 * Add extra protection verifying the Signature algorithm used on SignedInfo element, not only rely on the xmlseclibs verify / verifySignature methods.

--- a/phpsaml/advanced_settings_example.php
+++ b/phpsaml/advanced_settings_example.php
@@ -2,7 +2,7 @@
 
 $advancedSettings = array (
 
-    // Compression settings 
+    // Compression settings
     // Handle if the getRequest/getResponse methods will return the Request/Response deflated.
     // But if we provide a $deflate boolean parameter to the getRequest or getResponse
     // method it will have priority over the compression settings.
@@ -36,7 +36,11 @@ $advancedSettings = array (
          False || True (use sp certs) || array (
                                                     keyFileName => 'metadata.key',
                                                     certFileName => 'metadata.crt'
-                                                )
+                                               )
+                                      || array (
+                                                    'x509cert' => '',
+                                                    'privateKey' => ''
+                                               )
         */
         'signMetadata' => false,
 
@@ -80,6 +84,16 @@ $advancedSettings = array (
         // If true, SAMLResponses with an empty value at its Destination
         // attribute will not be rejected for this fact.
         'relaxDestinationValidation' => false,
+
+        // If true, Destination URL should strictly match to the address to
+        // which the response has been sent.
+        // Notice that if 'relaxDestinationValidation' is true an empty Destintation
+        // will be accepted.
+        'destinationStrictlyMatches' => false,
+
+        // If true, SAMLResponses with an InResponseTo value will be rejectd if not
+        // AuthNRequest ID provided to the validation method.
+        'rejectUnsolicitedResponsesWithInResponseTo' => false,
 
         // Algorithm that the toolkit will use on signing process. Options:
         //    'http://www.w3.org/2000/09/xmldsig#rsa-sha1'

--- a/phpsaml/extlib/xmlseclibs/CHANGELOG.txt
+++ b/phpsaml/extlib/xmlseclibs/CHANGELOG.txt
@@ -1,8 +1,64 @@
 xmlseclibs.php
-??, ??? ????, 2.0.0
-Features:
-- Support for locating specific signature when multiple exist in 
-  document. (griga3k)
+
+06, Nov 2019, 3.0.4
+Security Improvements:
+- Insure only a single SignedInfo element exists within a signature during 
+  verification. Refs CVE-2019-3465.
+Bug Fixes:
+- Fix variable casing.
+
+15, Nov 2018, 3.0.3
+Bug Fixes:
+- Fix casing of class name. (Willem Stuursma-Ruwen)
+- Fix Xpath casing. (Tim van Dijen)
+
+Improvements:
+- Make PCRE2 compliant. (Stefan Winter)
+- Add PHP 7.3 support. (Stefan Winter)
+
+27, Sep 2018, 3.0.2
+Security Improvements:
+- OpenSSL is now a requirement rather than suggestion. (Slaven Bacelic)
+- Filter input to avoid XPath injection. (Jaime Pérez)
+
+Bug Fixes:
+- Fix missing parentheses (Tim van Dijen)
+
+Improvements:
+- Use strict comparison operator to compare digest values. (Jaime Pérez)
+- Remove call to file_get_contents that doesn't even work. (Jaime Pérez)
+- Document potentially dangerous return value behaviour. (Thijs Kinkhorst)
+
+31, Aug 2017, 3.0.1
+Bug Fixes:
+- Fixed missing () in function call. (Dennis Væversted)
+
+Improvements:
+- Add OneLogin to supported software.
+- Add .gitattributes to remove unneeded files. (Filippo Tessarotto)
+- Fix bug in example code. (Dan Church)
+- Travis: add PHP 7.1, move hhvm to allowed failures. (Thijs Kinkhorst)
+- Drop failing extract-win-cert test (Thijs Kinkhorst). (Thijs Kinkhorst)
+- Add comments to warn about return values of verify(). (Thijs Kinkhorst)
+- Fix tests to properly check return code of verify(). (Thijs Kinkhorst)
+- Restore support for PHP >= 5.4. (Jaime Pérez)
+
+25, May 2017, 3.0.0
+Improvements:
+- Remove use of mcrypt (skymeyer)
+
+08, Sep 2016, 2.0.1
+Bug Fixes:
+- Strip whitespace characters when parsing X509Certificate. fixes #84
+  (klemen.bratec)
+- Certificate 'subject' values can be arrays. fixes #80 (Andreas Stangl)
+- HHVM signing node with ID attribute w/out namespace regenerates ID value.
+  fixes #88 (Milos Tomic)
+
+Improvements:
+- Fix typos and add some PHPDoc Blocks. (gfaust-qb)
+- Update lightSAML link. (Milos Tomic)
+- Update copyright dates.
 
 23, Jun 2015, 1.4.0
 Features:

--- a/phpsaml/extlib/xmlseclibs/LICENSE
+++ b/phpsaml/extlib/xmlseclibs/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2007-2013, Robert Richards <rrichards@cdatazone.org>.
+Copyright (c) 2007-2019, Robert Richards <rrichards@cdatazone.org>.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/phpsaml/extlib/xmlseclibs/xmlseclibs.php
+++ b/phpsaml/extlib/xmlseclibs/xmlseclibs.php
@@ -2,7 +2,7 @@
 /**
  * xmlseclibs.php
  *
- * Copyright (c) 2007-2015, Robert Richards <rrichards@cdatazone.org>.
+ * Copyright (c) 2007-2019, Robert Richards <rrichards@cdatazone.org>.
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -35,9 +35,9 @@
  * POSSIBILITY OF SUCH DAMAGE.
  *
  * @author     Robert Richards <rrichards@cdatazone.org>
- * @copyright  2007-2015 Robert Richards <rrichards@cdatazone.org>
+ * @copyright  2007-2019 Robert Richards <rrichards@cdatazone.org>
  * @license    http://www.opensource.org/licenses/bsd-license.php  BSD License
- * @version    2.0.0 modified
+ * @version    3.0.4 modified
  */
 
 class XMLSecurityKey {
@@ -589,6 +589,11 @@ class XMLSecurityDSig {
             $query = ".//secdsig:Signature";
             $nodeset = $xpath->query($query, $objDoc);
             $this->sigNode = $nodeset->item($pos);
+            $query = "./secdsig:SignedInfo";
+            $nodeset = $xpath->query($query, $this->sigNode);
+            if ($nodeset->length > 1) {
+                throw new Exception("Invalid structure - Too many SignedInfo elements found");
+            }
             return $this->sigNode;
         }
         return null;
@@ -675,6 +680,9 @@ class XMLSecurityDSig {
             $xpath = $this->getXPathObj();
             $query = "./secdsig:SignedInfo";
             $nodeset = $xpath->query($query, $this->sigNode);
+            if ($nodeset->length > 1) {
+                throw new Exception("Invalid structure - Too many SignedInfo elements found");
+            }
             if ($signInfoNode = $nodeset->item(0)) {
                 $query = "./secdsig:CanonicalizationMethod";
                 $nodeset = $xpath->query($query, $signInfoNode);
@@ -790,7 +798,7 @@ class XMLSecurityDSig {
                         if ($node->localName == 'XPath') {
                             $arXPath = array();
                             $arXPath['query'] = '(.//. | .//@* | .//namespace::*)['.$node->nodeValue.']';
-                            $arXpath['namespaces'] = array();
+                            $arXPath['namespaces'] = array();
                             $nslist = $xpath->query('./namespace::*', $node);
                             foreach ($nslist AS $nsnode) {
                                 if ($nsnode->localName != "xml") {
@@ -888,7 +896,7 @@ class XMLSecurityDSig {
         $refids = array();
 
         $xpath = $this->getXPathObj();
-        $query = "./secdsig:SignedInfo/secdsig:Reference";
+        $query = "./secdsig:SignedInfo[1]/secdsig:Reference";
         $nodeset = $xpath->query($query, $this->sigNode);
         if ($nodeset->length == 0) {
             throw new Exception("Reference nodes not found");
@@ -905,7 +913,7 @@ class XMLSecurityDSig {
             $this->sigNode->parentNode->removeChild($this->sigNode);
         }
         $xpath = $this->getXPathObj();
-        $query = "./secdsig:SignedInfo/secdsig:Reference";
+        $query = "./secdsig:SignedInfo[1]/secdsig:Reference";
         $nodeset = $xpath->query($query, $this->sigNode);
         if ($nodeset->length == 0) {
             throw new Exception("Reference nodes not found");

--- a/phpsaml/lib/Saml2/AuthnRequest.php
+++ b/phpsaml/lib/Saml2/AuthnRequest.php
@@ -29,11 +29,12 @@ class OneLogin_Saml2_AuthnRequest
      * Constructs the AuthnRequest object.
      *
      * @param OneLogin_Saml2_Settings $settings Settings
-     * @param bool   $forceAuthn      When true the AuthNReuqest will set the ForceAuthn='true'
-     * @param bool   $isPassive       When true the AuthNReuqest will set the Ispassive='true'
+     * @param bool   $forceAuthn When true the AuthNReuqest will set the ForceAuthn='true'
+     * @param bool   $isPassive When true the AuthNReuqest will set the Ispassive='true'
      * @param bool   $setNameIdPolicy When true the AuthNReuqest will set a nameIdPolicy
+     * @param string $nameIdValueReq Indicates to the IdP the subject that should be authenticated
      */
-    public function __construct(OneLogin_Saml2_Settings $settings, $forceAuthn = false, $isPassive = false, $setNameIdPolicy = true)
+    public function __construct(OneLogin_Saml2_Settings $settings, $forceAuthn = false, $isPassive = false, $setNameIdPolicy = true, $nameIdValueReq = null)
     {
         $this->_settings = $settings;
 
@@ -44,6 +45,17 @@ class OneLogin_Saml2_AuthnRequest
         $id = OneLogin_Saml2_Utils::generateUniqueID();
         $issueInstant = OneLogin_Saml2_Utils::parseTime2SAML(time());
 
+        $subjectStr = "";
+        if (isset($nameIdValueReq)) {
+            $subjectStr = <<<SUBJECT
+
+    <saml:Subject>
+        <saml:NameID Format="{$spData['NameIDFormat']}">{$nameIdValueReq}</saml:NameID>
+        <saml:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer"></saml:SubjectConfirmation>
+    </saml:Subject>
+SUBJECT;
+        }
+
         $nameIdPolicyStr = '';
         if ($setNameIdPolicy) {
             $nameIDPolicyFormat = $spData['NameIDFormat'];
@@ -52,6 +64,7 @@ class OneLogin_Saml2_AuthnRequest
             }
 
             $nameIdPolicyStr = <<<NAMEIDPOLICY
+
     <samlp:NameIDPolicy
         Format="{$nameIDPolicyFormat}"
         AllowCreate="true" />
@@ -93,20 +106,25 @@ ISPASSIVE;
 
         $requestedAuthnStr = '';
         if (isset($security['requestedAuthnContext']) && $security['requestedAuthnContext'] !== false) {
-
             $authnComparison = 'exact';
             if (isset($security['requestedAuthnContextComparison'])) {
                 $authnComparison = $security['requestedAuthnContextComparison'];
             }
 
+            $authnComparisonAttr = '';
+            if (!empty($authnComparison)) {
+                $authnComparisonAttr = sprintf('Comparison="%s"', $authnComparison);
+            }
+
             if ($security['requestedAuthnContext'] === true) {
                 $requestedAuthnStr = <<<REQUESTEDAUTHN
-    <samlp:RequestedAuthnContext Comparison="$authnComparison">
+
+    <samlp:RequestedAuthnContext $authnComparisonAttr>
         <saml:AuthnContextClassRef>urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport</saml:AuthnContextClassRef>
     </samlp:RequestedAuthnContext>
 REQUESTEDAUTHN;
             } else {
-                $requestedAuthnStr .= "    <samlp:RequestedAuthnContext Comparison=\"$authnComparison\">\n";
+                $requestedAuthnStr .= "    <samlp:RequestedAuthnContext $authnComparisonAttr>\n";
                 foreach ($security['requestedAuthnContext'] as $contextValue) {
                     $requestedAuthnStr .= "        <saml:AuthnContextClassRef>".$contextValue."</saml:AuthnContextClassRef>\n";
                 }
@@ -127,9 +145,7 @@ REQUESTEDAUTHN;
     Destination="{$idpData['singleSignOnService']['url']}"
     ProtocolBinding="{$spData['assertionConsumerService']['binding']}"
     AssertionConsumerServiceURL="{$acsUrl}">
-    <saml:Issuer>{$spEntityId}</saml:Issuer>
-{$nameIdPolicyStr}
-{$requestedAuthnStr}
+    <saml:Issuer>{$spEntityId}</saml:Issuer>{$subjectStr}{$nameIdPolicyStr}{$requestedAuthnStr}
 </samlp:AuthnRequest>
 AUTHNREQUEST;
 
@@ -141,6 +157,8 @@ AUTHNREQUEST;
      * Returns deflated, base64 encoded, unsigned AuthnRequest.
      *
      * @param bool|null $deflate Whether or not we should 'gzdeflate' the request body before we return it.
+     *
+     * @return string
      */
     public function getRequest($deflate = null)
     {

--- a/phpsaml/lib/Saml2/IdPMetadataParser.php
+++ b/phpsaml/lib/Saml2/IdPMetadataParser.php
@@ -40,6 +40,7 @@ class OneLogin_Saml2_IdPMetadataParser
                 throw new Exception(curl_error($ch), curl_errno($ch));
             }
         } catch (Exception $e) {
+            throw new Exception('Error on parseRemoteXML. '.$e->getMessage());
         }
         return $metadataInfo;
     }
@@ -68,6 +69,7 @@ class OneLogin_Saml2_IdPMetadataParser
                 $metadataInfo = self::parseXML($data, $entityId, $desiredNameIdFormat, $desiredSSOBinding, $desiredSLOBinding);
             }
         } catch (Exception $e) {
+            throw new Exception('Error on parseFileXML. '.$e->getMessage());
         }
         return $metadataInfo;
     }
@@ -85,7 +87,8 @@ class OneLogin_Saml2_IdPMetadataParser
      * @param string $desiredSLOBinding     Parse specific binding SLO endpoint.
      *
      * @return array metadata info in php-saml settings format
-     * @throws \Exception
+     *
+     * @throws Exception
      */
     public static function parseXML($xml, $entityId = null, $desiredNameIdFormat = null, $desiredSSOBinding = OneLogin_Saml2_Constants::BINDING_HTTP_REDIRECT, $desiredSLOBinding = OneLogin_Saml2_Constants::BINDING_HTTP_REDIRECT)
     {
@@ -141,6 +144,10 @@ class OneLogin_Saml2_IdPMetadataParser
                         'url' => $sloNodes->item(0)->getAttribute('Location'),
                         'binding' => $sloNodes->item(0)->getAttribute('Binding')
                     );
+
+                    if ($sloNodes->item(0)->hasAttribute('ResponseLocation')) {
+                        $metadataInfo['idp']['singleLogoutService']['responseUrl'] = $sloNodes->item(0)->getAttribute('ResponseLocation');
+                    }
                 }
 
                 $keyDescriptorCertSigningNodes = OneLogin_Saml2_Utils::query($dom, './md:KeyDescriptor[not(contains(@use, "encryption"))]/ds:KeyInfo/ds:X509Data/ds:X509Certificate', $idpDescriptor);

--- a/phpsaml/lib/Saml2/LogoutRequest.php
+++ b/phpsaml/lib/Saml2/LogoutRequest.php
@@ -33,14 +33,17 @@ class OneLogin_Saml2_LogoutRequest
     /**
      * Constructs the Logout Request object.
      *
-     * @param OneLogin_Saml2_Settings $settings     Settings
-     * @param string|null             $request      A UUEncoded Logout Request.
-     * @param string|null             $nameId       The NameID that will be set in the LogoutRequest.
-     * @param string|null             $sessionIndex The SessionIndex (taken from the SAML Response in the SSO process).
-     * @param string|null             $nameIdFormat The NameID Format will be set in the LogoutRequest.
-     * @param string|null             $nameIdNameQualifier The NameID NameQualifier will be set in the LogoutRequest.
+     * @param OneLogin_Saml2_Settings $settings Settings
+     * @param string|null $request A UUEncoded Logout Request.
+     * @param string|null $nameId The NameID that will be set in the LogoutRequest.
+     * @param string|null $sessionIndex The SessionIndex (taken from the SAML Response in the SSO process).
+     * @param string|null $nameIdFormat The NameID Format will be set in the LogoutRequest.
+     * @param string|null $nameIdNameQualifier The NameID NameQualifier will be set in the LogoutRequest.
+     * @param string|null             $nameIdSPNameQualifier The NameID SP NameQualifier will be set in the LogoutRequest.
+     *
+     * @throws OneLogin_Saml2_Error
      */
-    public function __construct(OneLogin_Saml2_Settings $settings, $request = null, $nameId = null, $sessionIndex = null, $nameIdFormat = null, $nameIdNameQualifier = null)
+    public function __construct(OneLogin_Saml2_Settings $settings, $request = null, $nameId = null, $sessionIndex = null, $nameIdFormat = null, $nameIdNameQualifier = null, $nameIdSPNameQualifier = null)
     {
         $this->_settings = $settings;
 
@@ -57,7 +60,6 @@ class OneLogin_Saml2_LogoutRequest
             $id = OneLogin_Saml2_Utils::generateUniqueID();
             $this->id = $id;
 
-            $nameIdValue = OneLogin_Saml2_Utils::generateUniqueID();
             $issueInstant = OneLogin_Saml2_Utils::parseTime2SAML(time());
 
             $cert = null;
@@ -76,16 +78,26 @@ class OneLogin_Saml2_LogoutRequest
                   $spData['NameIDFormat'] != OneLogin_Saml2_Constants::NAMEID_UNSPECIFIED) {
                     $nameIdFormat = $spData['NameIDFormat'];
                 }
-                $spNameQualifier = null;
             } else {
                 $nameId = $idpData['entityId'];
                 $nameIdFormat = OneLogin_Saml2_Constants::NAMEID_ENTITY;
-                $spNameQualifier = $spData['entityId'];
+            }
+
+            /* From saml-core-2.0-os 8.3.6, when the entity Format is used:
+               "The NameQualifier, SPNameQualifier, and SPProvidedID attributes MUST be omitted.
+            */
+            if (!empty($nameIdFormat) && $nameIdFormat == OneLogin_Saml2_Constants::NAMEID_ENTITY) {
+                $nameIdNameQualifier = null;
+                $nameIdSPNameQualifier = null;
+            }
+             // NameID Format UNSPECIFIED omitted
+            if (!empty($nameIdFormat) && $nameIdFormat == OneLogin_Saml2_Constants::NAMEID_UNSPECIFIED) {
+                $nameIdFormat = null;
             }
 
             $nameIdObj = OneLogin_Saml2_Utils::generateNameId(
                 $nameId,
-                $spNameQualifier,
+                $nameIdSPNameQualifier,
                 $nameIdFormat,
                 $cert,
                 $nameIdNameQualifier
@@ -150,6 +162,8 @@ LOGOUTREQUEST;
      * @param string|DOMDocument $request Logout Request Message
      *
      * @return string ID
+     *
+     * @throws OneLogin_Saml2_Error
      */
     public static function getID($request)
     {
@@ -158,6 +172,13 @@ LOGOUTREQUEST;
         } else {
             $dom = new DOMDocument();
             $dom = OneLogin_Saml2_Utils::loadXML($dom, $request);
+
+            if (false === $dom) {
+                throw new OneLogin_Saml2_Error(
+                    "LogoutRequest could not be processed",
+                    OneLogin_Saml2_Error::SAML_LOGOUTREQUEST_INVALID
+                );
+            }
         }
 
         $id = $dom->documentElement->getAttribute('ID');
@@ -168,11 +189,12 @@ LOGOUTREQUEST;
      * Gets the NameID Data of the the Logout Request.
      *
      * @param string|DOMDocument $request Logout Request Message
-     * @param string|null        $key     The SP key
+     * @param string|null $key The SP key
      *
      * @return array Name ID Data (Value, Format, NameQualifier, SPNameQualifier)
      *
-     * @throws Exception
+     * @throws OneLogin_Saml2_Error
+     * @throws OneLogin_Saml2_ValidationError
      */
     public static function getNameIdData($request, $key = null)
     {
@@ -230,9 +252,12 @@ LOGOUTREQUEST;
      * Gets the NameID of the Logout Request.
      *
      * @param string|DOMDocument $request Logout Request Message
-     * @param string|null        $key     The SP key
+     * @param string|null $key The SP key
      *
      * @return string Name ID Value
+     *
+     * @throws OneLogin_Saml2_Error
+     * @throws OneLogin_Saml2_ValidationError
      */
     public static function getNameId($request, $key = null)
     {
@@ -246,6 +271,7 @@ LOGOUTREQUEST;
      * @param string|DOMDocument $request Logout Request Message
      *
      * @return string|null $issuer The Issuer
+     * @throws Exception
      */
     public static function getIssuer($request)
     {
@@ -273,6 +299,8 @@ LOGOUTREQUEST;
      * @param string|DOMDocument $request Logout Request Message
      *
      * @return array The SessionIndex value
+     *
+     * @throws Exception
      */
     public static function getSessionIndexes($request)
     {
@@ -294,6 +322,8 @@ LOGOUTREQUEST;
     /**
      * Checks if the Logout Request recieved is valid.
      *
+     * @param bool $retrieveParametersFromServer
+     *
      * @return bool If the Logout Request is or not valid
      */
     public function isValid($retrieveParametersFromServer = false)
@@ -310,7 +340,7 @@ LOGOUTREQUEST;
                 $security = $this->_settings->getSecurityData();
 
                 if ($security['wantXMLValidation']) {
-                    $res = OneLogin_Saml2_Utils::validateXML($dom, 'saml-schema-protocol-2.0.xsd', $this->_settings->isDebugActive());
+                    $res = OneLogin_Saml2_Utils::validateXML($dom, 'saml-schema-protocol-2.0.xsd', $this->_settings->isDebugActive(), $this->_settings->getSchemasPath());
                     if (!$res instanceof DOMDocument) {
                         throw new OneLogin_Saml2_ValidationError(
                             "Invalid SAML Logout Request. Not match the saml-schema-protocol-2.0.xsd",
@@ -335,20 +365,33 @@ LOGOUTREQUEST;
                 // Check destination
                 if ($dom->documentElement->hasAttribute('Destination')) {
                     $destination = $dom->documentElement->getAttribute('Destination');
-                    if (!empty($destination)) {
-                        if (strpos($destination, $currentURL) === false) {
+                    if (empty($destination)) {
+                        if (!$security['relaxDestinationValidation']) {
                             throw new OneLogin_Saml2_ValidationError(
-                                "The LogoutRequest was received at $currentURL instead of $destination",
-                                OneLogin_Saml2_ValidationError::WRONG_DESTINATION
+                                "The LogoutRequest has an empty Destination value",
+                                OneLogin_Saml2_ValidationError::EMPTY_DESTINATION
                             );
+                        }
+                    } else {
+                        $urlComparisonLength = $security['destinationStrictlyMatches'] ? strlen($destination) : strlen($currentURL);
+                        if (strncmp($destination, $currentURL, $urlComparisonLength) !== 0) {
+                            $currentURLNoRouted = OneLogin_Saml2_Utils::getSelfURLNoQuery();
+                            $urlComparisonLength = $security['destinationStrictlyMatches'] ? strlen($destination) : strlen($currentURLNoRouted);
+
+                            if (strncmp($destination, $currentURLNoRouted, $urlComparisonLength) !== 0) {
+                                throw new OneLogin_Saml2_ValidationError(
+                                    "The LogoutRequest was received at $currentURL instead of $destination",
+                                    OneLogin_Saml2_ValidationError::WRONG_DESTINATION
+                                );
+                            }
                         }
                     }
                 }
 
-                $nameId = $this->getNameId($dom, $this->_settings->getSPkey());
+                $nameId = static::getNameId($dom, $this->_settings->getSPkey());
 
                 // Check issuer
-                $issuer = $this->getIssuer($dom);
+                $issuer = static::getIssuer($dom);
                 if (!empty($issuer) && $issuer != $idPEntityId) {
                     throw new OneLogin_Saml2_ValidationError(
                         "Invalid issuer in the Logout Request",
@@ -356,13 +399,11 @@ LOGOUTREQUEST;
                     );
                 }
 
-                if ($security['wantMessagesSigned']) {
-                    if (!isset($_GET['Signature'])) {
-                        throw new OneLogin_Saml2_ValidationError(
-                            "The Message of the Logout Request is not signed and the SP require it",
-                            OneLogin_Saml2_ValidationError::NO_SIGNED_MESSAGE
-                        );
-                    }
+                if ($security['wantMessagesSigned'] && !isset($_GET['Signature'])) {
+                    throw new OneLogin_Saml2_ValidationError(
+                        "The Message of the Logout Request is not signed and the SP require it",
+                        OneLogin_Saml2_ValidationError::NO_SIGNED_MESSAGE
+                    );
                 }
             }
 
@@ -387,7 +428,8 @@ LOGOUTREQUEST;
         }
     }
 
-    /* After execute a validation process, if fails this method returns the cause
+    /**
+     * After execute a validation process, if fails this method returns the cause
      *
      * @return string Cause
      */

--- a/phpsaml/lib/Saml2/Metadata.php
+++ b/phpsaml/lib/Saml2/Metadata.php
@@ -21,6 +21,7 @@ class OneLogin_Saml2_Metadata
      * @param array         $contacts      Contacts info
      * @param array         $organization  Organization ingo
      * @param array         $attributes
+     *
      * @return string SAML Metadata XML
      */
     public static function builder($sp, $authnsign = false, $wsign = false, $validUntil = null, $cacheDuration = null, $contacts = array(), $organization = array(), $attributes = array())
@@ -173,13 +174,15 @@ METADATA_TEMPLATE;
     /**
      * Signs the metadata with the key/cert provided
      *
-     * @param string $metadata          SAML Metadata XML
-     * @param string $key               x509 key
-     * @param string $cert              x509 cert
-     * @param string $signAlgorithm     Signature algorithm method
-     * @param string $digestAlgorithm   Digest algorithm method
+     * @param string $metadata SAML Metadata XML
+     * @param string $key x509 key
+     * @param string $cert x509 cert
+     * @param string $signAlgorithm Signature algorithm method
+     * @param string $digestAlgorithm Digest algorithm method
      *
      * @return string Signed Metadata
+     *
+     * @throws Exception
      */
     public static function signMetadata($metadata, $key, $cert, $signAlgorithm = XMLSecurityKey::RSA_SHA1, $digestAlgorithm = XMLSecurityDSig::SHA1)
     {
@@ -190,11 +193,13 @@ METADATA_TEMPLATE;
      * Adds the x509 descriptors (sign/encriptation) to the metadata
      * The same cert will be used for sign/encrypt
      *
-     * @param string $metadata       SAML Metadata XML
-     * @param string $cert           x509 cert
-     * @param bool   $wantsEncrypted Whether to include the KeyDescriptor for encryption
+     * @param string $metadata SAML Metadata XML
+     * @param string $cert x509 cert
+     * @param bool $wantsEncrypted Whether to include the KeyDescriptor for encryption
      *
      * @return string Metadata with KeyDescriptors
+     *
+     * @throws Exception
      */
     public static function addX509KeyDescriptors($metadata, $cert, $wantsEncrypted = true)
     {

--- a/phpsaml/lib/Saml2/Response.php
+++ b/phpsaml/lib/Saml2/Response.php
@@ -55,9 +55,10 @@ class OneLogin_Saml2_Response
      * Constructs the SAML Response object.
      *
      * @param OneLogin_Saml2_Settings $settings Settings.
-     * @param string                  $response A UUEncoded SAML response from the IdP.
+     * @param string $response A UUEncoded SAML response from the IdP.
      *
-     * @throws Exception
+     * @throws OneLogin_Saml2_Error
+     * @throws OneLogin_Saml2_ValidationError
      */
     public function __construct(OneLogin_Saml2_Settings $settings, $response)
     {
@@ -94,8 +95,6 @@ class OneLogin_Saml2_Response
      * @param string|null $requestId The ID of the AuthNRequest sent by this SP to the IdP
      *
      * @return bool Validate the document
-     *
-     * @throws Exception
      */
     public function isValid($requestId = null)
     {
@@ -116,7 +115,7 @@ class OneLogin_Saml2_Response
                 );
             }
 
-            $status = $this->checkStatus();
+            $this->checkStatus();
 
             $singleAssertion = $this->validateNumAssertions();
             if (!$singleAssertion) {
@@ -144,7 +143,7 @@ class OneLogin_Saml2_Response
 
                 if ($security['wantXMLValidation']) {
                     $errorXmlMsg = "Invalid SAML Response. Not match the saml-schema-protocol-2.0.xsd";
-                    $res = OneLogin_Saml2_Utils::validateXML($this->document, 'saml-schema-protocol-2.0.xsd', $this->_settings->isDebugActive());
+                    $res = OneLogin_Saml2_Utils::validateXML($this->document, 'saml-schema-protocol-2.0.xsd', $this->_settings->isDebugActive(), $this->_settings->getSchemasPath());
                     if (!$res instanceof DOMDocument) {
                         throw new OneLogin_Saml2_ValidationError(
                             $errorXmlMsg,
@@ -154,7 +153,7 @@ class OneLogin_Saml2_Response
 
                     # If encrypted, check also the decrypted document
                     if ($this->encrypted) {
-                        $res = OneLogin_Saml2_Utils::validateXML($this->decryptedDocument, 'saml-schema-protocol-2.0.xsd', $this->_settings->isDebugActive());
+                        $res = OneLogin_Saml2_Utils::validateXML($this->decryptedDocument, 'saml-schema-protocol-2.0.xsd', $this->_settings->isDebugActive(), $this->_settings->getSchemasPath());
                         if (!$res instanceof DOMDocument) {
                             throw new OneLogin_Saml2_ValidationError(
                                 $errorXmlMsg,
@@ -167,13 +166,26 @@ class OneLogin_Saml2_Response
 
                 $currentURL = OneLogin_Saml2_Utils::getSelfRoutedURLNoQuery();
                 
+                $responseInResponseTo = null;
                 if ($this->document->documentElement->hasAttribute('InResponseTo')) {
                     $responseInResponseTo = $this->document->documentElement->getAttribute('InResponseTo');
                 }
 
+                if (!isset($requestId) && isset($responseInResponseTo) && $security['rejectUnsolicitedResponsesWithInResponseTo']) {
+                    throw new OneLogin_Saml2_ValidationError(
+                        "The Response has an InResponseTo attribute: " . $responseInResponseTo . " while no InResponseTo was expected",
+                        OneLogin_Saml2_ValidationError::WRONG_INRESPONSETO
+                    );
+                }
+
                 // Check if the InResponseTo of the Response matchs the ID of the AuthNRequest (requestId) if provided
-                if (isset($requestId) && isset($responseInResponseTo)) {
-                    if ($requestId != $responseInResponseTo) {
+                if (isset($requestId) && $requestId != $responseInResponseTo) {
+                    if ($responseInResponseTo == null) {
+                        throw new OneLogin_Saml2_ValidationError(
+                            "No InResponseTo at the Response, but it was provided the requestId related to the AuthNRequest sent by the SP: $requestId",
+                            OneLogin_Saml2_ValidationError::WRONG_INRESPONSETO
+                        );
+                    } else {
                         throw new OneLogin_Saml2_ValidationError(
                             "The InResponseTo of the Response: $responseInResponseTo, does not match the ID of the AuthNRequest sent by the SP: $requestId",
                             OneLogin_Saml2_ValidationError::WRONG_INRESPONSETO
@@ -237,10 +249,12 @@ class OneLogin_Saml2_Response
                             );
                         }
                     } else {
-                        if (strpos($destination, $currentURL) !== 0) {
+                        $urlComparisonLength = $security['destinationStrictlyMatches'] ? strlen($destination) : strlen($currentURL);
+                        if (strncmp($destination, $currentURL, $urlComparisonLength) !== 0) {
                             $currentURLNoRouted = OneLogin_Saml2_Utils::getSelfURLNoQuery();
+                            $urlComparisonLength = $security['destinationStrictlyMatches'] ? strlen($destination) : strlen($currentURLNoRouted);
 
-                            if (strpos($destination, $currentURLNoRouted) !== 0) {
+                            if (strncmp($destination, $currentURLNoRouted, $urlComparisonLength) !== 0) {
                                 throw new OneLogin_Saml2_ValidationError(
                                     "The response was received at $currentURL instead of $destination",
                                     OneLogin_Saml2_ValidationError::WRONG_DESTINATION
@@ -357,7 +371,7 @@ class OneLogin_Saml2_Response
                 $encryptedIDNodes = OneLogin_Saml2_Utils::query($this->decryptedDocument, '/samlp:Response/saml:Assertion/saml:Subject/saml:EncryptedID');
                 if ($encryptedIDNodes->length > 0) {
                     throw new OneLogin_Saml2_ValidationError(
-                        'Unsigned SAML Response that contains a signed and encrypted Assertion with encrypted nameId is not supported.',
+                        'SAML Response that contains a an encrypted Assertion with encrypted nameId is not supported.',
                         OneLogin_Saml2_ValidationError::NOT_SUPPORTED
                     );
                 }
@@ -422,6 +436,8 @@ class OneLogin_Saml2_Response
 
     /**
      * @return string|null the ID of the assertion in the Response
+     *
+     * @throws InvalidArgumentException
      */
     public function getAssertionId()
     {
@@ -430,10 +446,8 @@ class OneLogin_Saml2_Response
         }
         $assertionNodes = $this->_queryAssertion("");
         $id = null;
-        if ($assertionNodes->length == 1) {
-            if ($assertionNodes->item(0)->hasAttribute('ID')) {
-                $id = $assertionNodes->item(0)->getAttribute('ID');
-            }
+        if ($assertionNodes->length == 1 && $assertionNodes->item(0)->hasAttribute('ID')) {
+            $id = $assertionNodes->item(0)->getAttribute('ID');
         }
         return $id;
     }
@@ -450,7 +464,7 @@ class OneLogin_Saml2_Response
     /**
      * Checks if the Status is success
      *
-     * @throws $statusExceptionMsg If status is not success
+     * @throws OneLogin_Saml2_ValidationError If status is not success
      */
     public function checkStatus()
     {
@@ -525,6 +539,7 @@ class OneLogin_Saml2_Response
      * Gets the Issuers (from Response and Assertion).
      *
      * @return array @issuers The issuers of the assertion/response
+     *
      * @throws OneLogin_Saml2_ValidationError
      */
     public function getIssuers()
@@ -560,6 +575,8 @@ class OneLogin_Saml2_Response
      * Gets the NameID Data provided by the SAML response from the IdP.
      *
      * @return array Name ID Data (Value, Format, NameQualifier, SPNameQualifier)
+     *
+     * @throws OneLogin_Saml2_ValidationError
      */
     public function getNameIdData()
     {
@@ -624,6 +641,8 @@ class OneLogin_Saml2_Response
      * Gets the NameID provided by the SAML response from the IdP.
      *
      * @return string|null Name ID Value
+     *
+     * @throws OneLogin_Saml2_ValidationError
      */
     public function getNameId()
     {
@@ -639,6 +658,8 @@ class OneLogin_Saml2_Response
      * Gets the NameID Format provided by the SAML response from the IdP.
      *
      * @return string|null Name ID Format
+     *
+     * @throws OneLogin_Saml2_ValidationError
      */
     public function getNameIdFormat()
     {
@@ -654,6 +675,8 @@ class OneLogin_Saml2_Response
      * Gets the NameID NameQualifier provided by the SAML response from the IdP.
      *
      * @return string|null Name ID NameQualifier
+     *
+     * @throws OneLogin_Saml2_ValidationError
      */
     public function getNameIdNameQualifier()
     {
@@ -666,10 +689,29 @@ class OneLogin_Saml2_Response
     }
 
     /**
+     * Gets the NameID SP NameQualifier provided by the SAML response from the IdP.
+     *
+     * @return string|null NameID SP NameQualifier
+     *
+     * @throws ValidationError
+     */
+    public function getNameIdSPNameQualifier()
+    {
+        $nameIdSPNameQualifier = null;
+        $nameIdData = $this->getNameIdData();
+        if (!empty($nameIdData) && isset($nameIdData['SPNameQualifier'])) {
+            $nameIdSPNameQualifier = $nameIdData['SPNameQualifier'];
+        }
+        return $nameIdSPNameQualifier;
+    }
+
+    /**
      * Gets the SessionNotOnOrAfter from the AuthnStatement.
      * Could be used to set the local session expiration
      *
      * @return int|null The SessionNotOnOrAfter value
+     *
+     * @throws Exception
      */
     public function getSessionNotOnOrAfter()
     {
@@ -704,6 +746,8 @@ class OneLogin_Saml2_Response
      * Gets the Attributes from the AttributeStatement element.
      *
      * @return array The attributes of the SAML Assertion
+     *
+     * @throws OneLogin_Saml2_ValidationError
      */
     public function getAttributes()
     {
@@ -714,13 +758,22 @@ class OneLogin_Saml2_Response
      * Gets the Attributes from the AttributeStatement element using their FriendlyName.
      *
      * @return array The attributes of the SAML Assertion
+     *
+     * @throws OneLogin_Saml2_ValidationError
      */
     public function getAttributesWithFriendlyName()
     {
         return $this->_getAttributesByKeyName('FriendlyName');
     }
 
-    private function _getAttributesByKeyName($keyName="Name")
+    /**
+     * @param string $keyName
+     *
+     * @return array
+     *
+     * @throws OneLogin_Saml2_ValidationError
+     */
+    private function _getAttributesByKeyName($keyName = "Name")
     {
         $attributes = array();
 
@@ -782,6 +835,8 @@ class OneLogin_Saml2_Response
      *   - Check that IDs and reference URI are unique and consistent.
      *
      * @return array Signed element tags
+     *
+     * @throws OneLogin_Saml2_ValidationError
      */
     public function processSignedElements()
     {
@@ -855,14 +910,12 @@ class OneLogin_Saml2_Response
             $signedElements[] = $signedElement;
         }
 
-        if (!empty($signedElements)) {
-            // Check SignedElements
-            if (!$this->validateSignedElements($signedElements)) {
-                throw new OneLogin_Saml2_ValidationError(
-                    'Found an unexpected Signature Element. SAML Response rejected',
-                    OneLogin_Saml2_ValidationError::UNEXPECTED_SIGNED_ELEMENTS
-                );
-            }
+        // Check SignedElements
+        if (!empty($signedElements) && !$this->validateSignedElements($signedElements)) {
+            throw new OneLogin_Saml2_ValidationError(
+                'Found an unexpected Signature Element. SAML Response rejected',
+                OneLogin_Saml2_ValidationError::UNEXPECTED_SIGNED_ELEMENTS
+            );
         }
         return $signedElements;
     }
@@ -871,6 +924,9 @@ class OneLogin_Saml2_Response
      * Verifies that the document is still valid according Conditions Element.
      *
      * @return bool
+     *
+     * @throws Exception
+     * @throws OneLogin_Saml2_ValidationError
      */
     public function validateTimestamps()
     {
@@ -884,13 +940,13 @@ class OneLogin_Saml2_Response
         for ($i = 0; $i < $timestampNodes->length; $i++) {
             $nbAttribute = $timestampNodes->item($i)->attributes->getNamedItem("NotBefore");
             $naAttribute = $timestampNodes->item($i)->attributes->getNamedItem("NotOnOrAfter");
-            if ($nbAttribute && OneLogin_SAML2_Utils::parseSAML2Time($nbAttribute->textContent) > time() + OneLogin_Saml2_Constants::ALLOWED_CLOCK_DRIFT) {
+            if ($nbAttribute && OneLogin_Saml2_Utils::parseSAML2Time($nbAttribute->textContent) > time() + OneLogin_Saml2_Constants::ALLOWED_CLOCK_DRIFT) {
                 throw new OneLogin_Saml2_ValidationError(
                     'Could not validate timestamp: not yet valid. Check system clock.',
                     OneLogin_Saml2_ValidationError::ASSERTION_TOO_EARLY
                 );
             }
-            if ($naAttribute && OneLogin_SAML2_Utils::parseSAML2Time($naAttribute->textContent) + OneLogin_Saml2_Constants::ALLOWED_CLOCK_DRIFT <= time()) {
+            if ($naAttribute && OneLogin_Saml2_Utils::parseSAML2Time($naAttribute->textContent) + OneLogin_Saml2_Constants::ALLOWED_CLOCK_DRIFT <= time()) {
                 throw new OneLogin_Saml2_ValidationError(
                     'Could not validate timestamp: expired. Check system clock.',
                     OneLogin_Saml2_ValidationError::ASSERTION_EXPIRED
@@ -903,7 +959,11 @@ class OneLogin_Saml2_Response
     /**
      * Verifies that the document has the expected signed nodes.
      *
+     * @param $signedElements
+     *
      * @return bool
+     *
+     * @throws OneLogin_Saml2_ValidationError
      */
     public function validateSignedElements($signedElements)
     {
@@ -950,11 +1010,9 @@ class OneLogin_Saml2_Response
     /**
      * Extracts a node from the DOMDocument (Assertion).
      *
-     * @param string $assertionXpath Xpath Expresion
+     * @param string $assertionXpath Xpath Expression
      *
      * @return DOMNodeList The queried node
-     *
-     * @throws Exception
      */
     protected function _queryAssertion($assertionXpath)
     {
@@ -1023,19 +1081,18 @@ class OneLogin_Saml2_Response
      *
      * @return DOMDocument Decrypted Assertion
      *
-     * @throws Exception
+     * @throws OneLogin_Saml2_Error
+     * @throws OneLogin_Saml2_ValidationError
      */
     protected function _decryptAssertion($dom)
     {
         $pem = $this->_settings->getSPkey();
-
         if (empty($pem)) {
             throw new OneLogin_Saml2_Error(
                 "No private key available, check settings",
                 OneLogin_Saml2_Error::PRIVATE_KEY_NOT_FOUND
             );
         }
-
         $objenc = new XMLSecEnc();
         $encData = $objenc->locateEncryptedData($dom);
         if (!$encData) {
@@ -1044,7 +1101,6 @@ class OneLogin_Saml2_Response
                 OneLogin_Saml2_ValidationError::MISSING_ENCRYPTED_ELEMENT
             );
         }
-
         $objenc->setNode($encData);
         $objenc->type = $encData->getAttribute("Type");
         if (!$objKey = $objenc->locateKey()) {
@@ -1053,7 +1109,6 @@ class OneLogin_Saml2_Response
                 OneLogin_Saml2_ValidationError::KEY_ALGORITHM_ERROR
             );
         }
-
         $key = null;
         if ($objKeyInfo = $objenc->locateKeyInfo($objKey)) {
             if ($objKeyInfo->isEncrypted) {
@@ -1069,22 +1124,26 @@ class OneLogin_Saml2_Response
         if (empty($objKey->key)) {
             $objKey->loadKey($key);
         }
-
-        $decrypted = $objenc->decryptNode($objKey, true);
-
-        if ($decrypted instanceof DOMDocument) {
+        $decryptedXML = $objenc->decryptNode($objKey, false);
+        $decrypted = new DOMDocument();
+        $check = OneLogin_Saml2_Utils::loadXML($decrypted, $decryptedXML);
+        if ($check === false) {
+            throw new Exception('Error: string from decrypted assertion could not be loaded into a XML document');
+        }
+        if ($encData->parentNode instanceof DOMDocument) {
             return $decrypted;
         } else {
-            $encryptedAssertion = $decrypted->parentNode;
+            $decrypted = $decrypted->documentElement;
+            $encryptedAssertion = $encData->parentNode;
             $container = $encryptedAssertion->parentNode;
 
-            # Fix possible issue with saml namespace
-            if (!$decrypted->hasAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:saml') &&
-              !$decrypted->hasAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:saml2') &&
-              !$decrypted->hasAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns') &&
-              !$container->hasAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:saml') &&
-              !$container->hasAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:saml2')
-              ) {
+            // Fix possible issue with saml namespace
+            if (!$decrypted->hasAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:saml')
+                && !$decrypted->hasAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:saml2')
+                && !$decrypted->hasAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns')
+                && !$container->hasAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:saml')
+                && !$container->hasAttributeNS('http://www.w3.org/2000/xmlns/', 'xmlns:saml2')
+            ) {
                 if (strpos($encryptedAssertion->tagName, 'saml2:') !== false) {
                     $ns = 'xmlns:saml2';
                 } else if (strpos($encryptedAssertion->tagName, 'saml:') !== false) {
@@ -1092,26 +1151,28 @@ class OneLogin_Saml2_Response
                 } else {
                     $ns = 'xmlns';
                 }
-
                 $decrypted->setAttributeNS('http://www.w3.org/2000/xmlns/', $ns, OneLogin_Saml2_Constants::NS_SAML);
             }
 
-            $container->replaceChild($decrypted, $encryptedAssertion);
+            OneLogin_Saml2_Utils::treeCopyReplace($encryptedAssertion, $decrypted);
 
-            return $decrypted->ownerDocument;
+            // Rebuild the DOM will fix issues with namespaces as well
+            $dom = new DOMDocument();
+            return OneLogin_Saml2_Utils::loadXML($dom, $container->ownerDocument->saveXML());
         }
     }
 
-    /* After execute a validation process, if fails this method returns the cause
+    /**
+     * After execute a validation process, if fails this method returns the cause
      *
-     * @return string Cause 
+     * @return string Cause
      */
     public function getError()
     {
         return $this->_error;
     }
 
-    /*
+    /**
      * Returns the SAML Response document (If contains an encrypted assertion, decrypts it)
      *
      * @return DomDocument SAML Response

--- a/phpsaml/lib/Saml2/version.json
+++ b/phpsaml/lib/Saml2/version.json
@@ -1,6 +1,6 @@
 {
     "php-saml": {
-        "version": "2.13.0",
-        "released": "05/03/2017"
+        "version": "2.18.1",
+        "released": "25/11/2019"
     }
 }

--- a/phpsaml/settings_example.php
+++ b/phpsaml/settings_example.php
@@ -5,7 +5,7 @@ $settings = array (
     // or unencrypted messages if it expects them signed or encrypted
     // Also will reject the messages if not strictly follow the SAML
     // standard: Destination, NameId, Conditions ... are validated too.
-    'strict' => false,
+    'strict' => true,
 
     // Enable debug mode (to print errors)
     'debug' => false,
@@ -27,14 +27,14 @@ $settings = array (
             'url' => '',
             // SAML protocol binding to be used when returning the <Response>
             // message.  Onelogin Toolkit supports for this endpoint the
-            // HTTP-Redirect binding only
+            // HTTP-POST binding only
             'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST',
         ),
         // If you need to specify requested attributes, set a
         // attributeConsumingService. nameFormat, attributeValue and
         // friendlyName can be omitted. Otherwise remove this section.
         "attributeConsumingService"=> array(
-                "ServiceName" => "SP test",
+                "serviceName" => "SP test",
                 "serviceDescription" => "Test Service",
                 "requestedAttributes" => array(
                     array(
@@ -86,13 +86,16 @@ $settings = array (
             'url' => '',
             // SAML protocol binding to be used when returning the <Response>
             // message.  Onelogin Toolkit supports for this endpoint the
-            // HTTP-POST binding only
+            // HTTP-Redirect binding only
             'binding' => 'urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect',
         ),
         // SLO endpoint info of the IdP.
         'singleLogoutService' => array (
             // URL Location of the IdP where the SP will send the SLO Request
             'url' => '',
+            // URL location of the IdP where the SP will send the SLO Response (ResponseLocation)
+            // if not set, url for the SLO Request will be used
+            'responseUrl' => '',
             // SAML protocol binding to be used when returning the <Response>
             // message.  Onelogin Toolkit supports for this endpoint the
             // HTTP-Redirect binding only


### PR DESCRIPTION
Updated repository includes latest v2 release of OneLogin's PHP SAML Library, which itself features an updated version of the vulnerable XMLSecLibs Library. This change should fix vulnerability relating to [CVE-2019-3465 ](https://nvd.nist.gov/vuln/detail/CVE-2019-3465) present in the current XMLSecLibs version.

Recommend testing before implementation. All testing on my end has come up clean so far, but PHP extensions aren't my area of expertise.