### PR TITLE
Change new user check to use getUserData

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -76,18 +76,18 @@ class auth_plugin_adfs extends auth_plugin_authplain
 
                     if ($this->getConf('autoprovisioning')) {
                         // In case of auto-provisionning we override the local DB info with those retrieve during the SAML negociation
-                        if (
-                            $this->triggerUserMod('modify', array(
-                                $USERINFO['user'],
-                                $USERINFO
-                            )) === false
-                        ) {
+                        if ( $this->getUserData($USERINFO['user']) === false ) {
                             $this->triggerUserMod('create', array(
                                 $USERINFO['user'],
                                 "\0\0nil\0\0",
                                 $USERINFO['name'],
                                 $USERINFO['mail'],
                                 $USERINFO['grps']
+                            ));
+                        } else {
+                            $this->triggerUserMod('modify', array(
+                                  $USERINFO['user'],
+                                  $USERINFO
                             ));
                         }
                     } else {


### PR DESCRIPTION
`authplain`'s `modifyUser` function outputs an error message via the `msg` function when called for a user that does not exist. Due to other issues with `getLang` and scoping, this just creates an error box with no message, as no lang mappings exist for this plugin that match those used in `authplain`'s code. An error message would not make sense anyways. I think it makes more sense to use `getUserData` and check for a falsey value.