### PR TITLE
Implement the logoff of dokuwiki in saml/adfs context but not SLO

### DIFF
--- a/action.php
+++ b/action.php
@@ -17,7 +17,8 @@ class action_plugin_adfs extends DokuWiki_Action_Plugin
 
     /**
      * Send the Federation Metadata about this Service Provider
-     *
+     * Otherwise, handle Logout for ADFS plugin
+     * 
      * @param Doku_Event $event
      * @param mixed $param
      */
@@ -44,7 +45,7 @@ class action_plugin_adfs extends DokuWiki_Action_Plugin
                 $errors = $saml->getErrors();
 
                 if (!empty($errors)) {
-                    msg('ADFS SLO:' . implode(', ', $errors), -1);
+                    msg('ADFS SLO: '. implode(', ', $errors) . '; ' . $saml->getLastErrorReason(), -1);
                 }
 
                 /* If a RelayState is defined in the Request, this is where we want to redirect to afterwards */

--- a/action.php
+++ b/action.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * ADFS SAML authentication plugin
  *
@@ -23,13 +24,18 @@ class action_plugin_adfs extends DokuWiki_Action_Plugin
     public function handle_request(Doku_Event $event, $param)
     {
         $act = act_clean($event->data);
-        if ($act != 'adfs') return;
+        if ($act != 'adfs' && $act != 'logout') return;
         $event->preventDefault();
         $event->stopPropagation();
 
         /** @var helper_plugin_adfs $hlp */
         $hlp = plugin_load('helper', 'adfs');
         $saml = $hlp->getSamlLib();
+
+        if ($act == "logout") { 
+            auth_logoff();
+            $saml->logout();
+        }
 
         try {
             header('Content-Type: application/samlmetadata+xml');
@@ -57,5 +63,4 @@ class action_plugin_adfs extends DokuWiki_Action_Plugin
         $event->data = new Doku_Form(array());
         $event->data->addElement('<a href="' . wl($ID, array('do' => 'login')) . '">Login here</a>');
     }
-
 }

--- a/action.php
+++ b/action.php
@@ -32,13 +32,30 @@ class action_plugin_adfs extends DokuWiki_Action_Plugin
         $hlp = plugin_load('helper', 'adfs');
         $saml = $hlp->getSamlLib();
 
-        if ($act == "logout") { 
+        if ($act == "logout") {
+            /* By default, try to return to user to the page they were just viewing */
+            $redirTo = wl($ID, array('do' => 'show'), true, '&');
+
             auth_logoff();
-            if($this->getConf('use_slo')) {
-                $saml->logout();
-            } else {
-                send_redirect(wl($ID, array('do' => 'show'), true, '&'));
+
+            /* Proccess an SLO request or response */
+            if (isset($_GET["SAMLResponse"]) || isset($_GET["SAMLRequest"])) {
+                $saml->processSLO();
+                $errors = $saml->getErrors();
+
+                if (!empty($errors)) {
+                    msg('ADFS SLO:' . implode(', ', $errors), -1);
+                }
+
+                /* If a RelayState is defined in the Request, this is where we want to redirect to afterwards */
+                if (isset($_GET["RelayState"])) $redirTo = $_GET["RelayState"];
+
+                /* If user initiates logout from the wiki itself */
+            } else if ($this->getConf('use_slo')) {
+                $saml->logout($redirTo);
             }
+
+            send_redirect($redirTo);
             exit();
         }
 

--- a/action.php
+++ b/action.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * ADFS SAML authentication plugin
  *
@@ -17,48 +16,20 @@ class action_plugin_adfs extends DokuWiki_Action_Plugin
 
     /**
      * Send the Federation Metadata about this Service Provider
-     * Otherwise, handle Logout for ADFS plugin
-     * 
+     *
      * @param Doku_Event $event
      * @param mixed $param
      */
     public function handle_request(Doku_Event $event, $param)
     {
         $act = act_clean($event->data);
-        if ($act != 'adfs' && $act != 'logout') return;
+        if ($act != 'adfs') return;
         $event->preventDefault();
         $event->stopPropagation();
 
         /** @var helper_plugin_adfs $hlp */
         $hlp = plugin_load('helper', 'adfs');
         $saml = $hlp->getSamlLib();
-
-        if ($act == "logout") {
-            /* By default, try to return to user to the page they were just viewing */
-            $redirTo = wl($ID, array('do' => 'show'), true, '&');
-
-            auth_logoff();
-
-            /* Proccess an SLO request or response */
-            if (isset($_GET["SAMLResponse"]) || isset($_GET["SAMLRequest"])) {
-                $saml->processSLO();
-                $errors = $saml->getErrors();
-
-                if (!empty($errors)) {
-                    msg('ADFS SLO: '. implode(', ', $errors) . '; ' . $saml->getLastErrorReason(), -1);
-                }
-
-                /* If a RelayState is defined in the Request, this is where we want to redirect to afterwards */
-                if (isset($_GET["RelayState"])) $redirTo = $_GET["RelayState"];
-
-                /* If user initiates logout from the wiki itself */
-            } else if ($this->getConf('use_slo')) {
-                $saml->logout($redirTo);
-            }
-
-            send_redirect($redirTo);
-            exit();
-        }
 
         try {
             header('Content-Type: application/samlmetadata+xml');
@@ -86,4 +57,5 @@ class action_plugin_adfs extends DokuWiki_Action_Plugin
         $event->data = new Doku_Form(array());
         $event->data->addElement('<a href="' . wl($ID, array('do' => 'login')) . '">Login here</a>');
     }
+
 }

--- a/action.php
+++ b/action.php
@@ -34,7 +34,12 @@ class action_plugin_adfs extends DokuWiki_Action_Plugin
 
         if ($act == "logout") { 
             auth_logoff();
-            $saml->logout();
+            if($this->getConf('use_slo')) {
+                $saml->logout();
+            } else {
+                send_redirect(wl($ID, array('do' => 'show'), true, '&'));
+            }
+            exit();
         }
 
         try {

--- a/auth.php
+++ b/auth.php
@@ -54,6 +54,7 @@ class auth_plugin_adfs extends auth_plugin_authplain
         }
 
         if (!isset($_POST['SAMLResponse']) && ($ACT == 'login' || get_doku_pref('adfs_autologin', 0))) {
+#if (!isset($_POST['SAMLResponse']) && ($ACT == 'login' )) {
             // Initiate SAML auth request
             $url = $this->saml->login(
                 null, // returnTo: is configured in our settings
@@ -134,8 +135,29 @@ class auth_plugin_adfs extends auth_plugin_authplain
 
     /** @inheritdoc */
     public function logOff()
-    {
+    {   
+        
+        global $ID;                       
         set_doku_pref('adfs_autologin', 0);
+
+        if (empty($ID)) $ID = getID();     
+        $go = wl($ID, '', true, '&');
+        
+        // start implementation of SAML logout
+        if (!$this->getConf('use_slo') or empty($this->getConf('slo_endpoint'))) {     // slo is not configured fall back to disconnect only from dokuwiki
+            send_redirect($go);
+        } else {                             // prepare the request  
+           send_redirect($go);               // !!!! remove this line when slo is implemented
+           $url = $this->saml->logout(       // function defined in adfs/phpsaml/lib/Saml2/Auth-php !!!!
+                   null, // returnTo: is configured in our settings                           (let is as it is in login: impemented in own cookie for now)
+                   [],   // parameter: we do not send any additional paramters to ADFS        (none)
+                   null, // The NameID that will be set in the LogoutRequest.                 (set to null as starting point, should be change propably)                   
+                   null, // The SessionIndex (taken from the SAML Response in the SSO process)(set to null as starting point, should be changed))
+                   true, // stay: do not redirect, we do that ourselves                       (let it as is is in login)
+                   null, // The NameID Format will be set in the LogoutRequest.               (set to null, can stay like that probably) 
+                   null // The NameID NameQualifier will be set in the LogoutRequest.        (set to null, can stay like that probably)
+               );
+        }
     }
 
     /** @inheritdoc */

--- a/auth.php
+++ b/auth.php
@@ -54,7 +54,6 @@ class auth_plugin_adfs extends auth_plugin_authplain
         }
 
         if (!isset($_POST['SAMLResponse']) && ($ACT == 'login' || get_doku_pref('adfs_autologin', 0))) {
-#if (!isset($_POST['SAMLResponse']) && ($ACT == 'login' )) {
             // Initiate SAML auth request
             $url = $this->saml->login(
                 null, // returnTo: is configured in our settings

--- a/conf/default.php
+++ b/conf/default.php
@@ -5,6 +5,7 @@
 
 $conf['idPEntityID'] = 'set me';
 $conf['endpoint']  = '';
+$conf['slo_endpoint']  = '';
 $conf['certificate'] = '';
 $conf['lowercase'] = 1;
 $conf['autoprovisioning'] = 1;

--- a/conf/default.php
+++ b/conf/default.php
@@ -9,6 +9,7 @@ $conf['slo_endpoint']  = '';
 $conf['certificate'] = '';
 $conf['lowercase'] = 1;
 $conf['autoprovisioning'] = 1;
+$conf['use_slo'] = 0;
 $conf['userid_attr_name'] = 'login';
 $conf['fullname_attr_name'] = 'fullname';
 $conf['email_attr_name'] = 'email';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -5,6 +5,7 @@
 
 $meta['idPEntityID'] = array('string');
 $meta['endpoint']    = array('string');
+$meta['slo_endpoint']    = array('string');
 $meta['certificate'] = array('');
 $meta['lowercase']   = array('onoff');
 $meta['autoprovisioning'] = array('onoff');

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -9,6 +9,7 @@ $meta['slo_endpoint']    = array('string');
 $meta['certificate'] = array('');
 $meta['lowercase']   = array('onoff');
 $meta['autoprovisioning'] = array('onoff');
+$meta['use_slo']   = array('onoff');
 $meta['userid_attr_name'] = array('string');
 $meta['fullname_attr_name'] = array('string');
 $meta['email_attr_name'] = array('string');

--- a/helper.php
+++ b/helper.php
@@ -67,6 +67,10 @@ class helper_plugin_adfs extends auth_plugin_authplain
                     'url' => $this->getConf('endpoint'),
                     'binding' => OneLogin_Saml2_Constants::BINDING_HTTP_REDIRECT,
                 ],
+                'singleLogoutService' => [
+                    'url' => $this->getConf('slo_endpoint'),
+                    'binding' => OneLogin_Saml2_Constants::BINDING_HTTP_REDIRECT,
+                ],                
                 'NameIDFormat' => OneLogin_Saml2_Constants::NAMEID_UNSPECIFIED,
                 'x509cert' => $cert,
             ],

--- a/helper.php
+++ b/helper.php
@@ -81,7 +81,8 @@ class helper_plugin_adfs extends auth_plugin_authplain
 
             'security' => [
                 'requestedAuthnContext' => false, // We let the AD decide what kind of authentication it uses
-                'wantNameId' => false // Seems not to work otherwise
+                'wantNameId' => false, // Seems not to work otherwise
+                'destinationStrictlyMatches' => false
             ],
 
             'organization' => array(

--- a/helper.php
+++ b/helper.php
@@ -58,7 +58,8 @@ class helper_plugin_adfs extends auth_plugin_authplain
                     "requestedAttributes" => [],
                 ],
                 'singleLogoutService' => [
-                    'url' => wl('', array('do' => 'logout'), true, '&'),
+                    //'url' => wl('', array('do' => 'logout'), true, '&'), // Seems wrong to me (Bonomani)
+                    //'url' => DOKU_URL . DOKU_SCRIPT,                     // something like that better
                     'binding' => OneLogin_Saml2_Constants::BINDING_HTTP_REDIRECT,
                 ],
                 'NameIDFormat' => OneLogin_Saml2_Constants::NAMEID_EMAIL_ADDRESS,
@@ -81,8 +82,7 @@ class helper_plugin_adfs extends auth_plugin_authplain
 
             'security' => [
                 'requestedAuthnContext' => false, // We let the AD decide what kind of authentication it uses
-                'wantNameId' => false, // Seems not to work otherwise
-                'destinationStrictlyMatches' => false
+                'wantNameId' => false // Seems not to work otherwise
             ],
 
             'organization' => array(

--- a/helper.php
+++ b/helper.php
@@ -57,6 +57,10 @@ class helper_plugin_adfs extends auth_plugin_authplain
                     "serviceDescription" => 'ADFS auth plugin',
                     "requestedAttributes" => [],
                 ],
+                'singleLogoutService' => [
+                    'url' => wl('', array('do' => 'logout'), true, '&'),
+                    'binding' => OneLogin_Saml2_Constants::BINDING_HTTP_REDIRECT,
+                ],
                 'NameIDFormat' => OneLogin_Saml2_Constants::NAMEID_EMAIL_ADDRESS,
             ],
 

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -5,9 +5,11 @@
 
 $lang['idPEntityID'] = 'The ID of your SAML server. Usually <code>http://<i>&lt;yourserver&gt;</i>/adfs/services/trust</code>';
 $lang['endpoint']    = 'The SAML auth API endpoint. Usually <code>https://<i>&lt;yourserver&gt;</i>/adfs/ls/</code>';
+$lang['slo_endpoint']    = 'The SAML auth API endpoint for the Single Logout service. Usually <code>https://<i>&lt;yourserver&gt;</i>/adfs/ls/</code>';
 $lang['certificate'] = 'The SAML auth certificate';
 $lang['lowercase'] = 'Treat user and group names as case insensitive and lower case them automatically?';
 $lang['autoprovisioning'] = 'Automatic user provisioning: authenticated users are created automatically and do not need to be added manually by the wiki administrator';
+$lang['use_slo'] = 'Whether to bounce back to the SP to complete a Single Logoff or to just kill the current DokuWiki session';
 $lang['userid_attr_name'] = 'User login name attribute';
 $lang['fullname_attr_name'] = 'Full name attribute';
 $lang['email_attr_name'] = 'E-mail attribute';

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -5,7 +5,7 @@
 
 $lang['idPEntityID'] = 'The ID of your SAML server. Usually <code>http://<i>&lt;yourserver&gt;</i>/adfs/services/trust</code>';
 $lang['endpoint']    = 'The SAML auth API endpoint. Usually <code>https://<i>&lt;yourserver&gt;</i>/adfs/ls/</code>';
-$lang['slo_endpoint']    = 'The SAML auth API endpoint for the Single Logout service. Usually <code>https://<i>&lt;yourserver&gt;</i>/adfs/ls/</code>';
+$lang['slo_endpoint']    = 'The SAML auth API endpoint for the Single Logout service. Usually <code>https://<i>&lt;yourserver&gt;</i>/adfs/ls/ ! NOT IMPLEMENTED !</code>';
 $lang['certificate'] = 'The SAML auth certificate';
 $lang['lowercase'] = 'Treat user and group names as case insensitive and lower case them automatically?';
 $lang['autoprovisioning'] = 'Automatic user provisioning: authenticated users are created automatically and do not need to be added manually by the wiki administrator';
@@ -14,5 +14,3 @@ $lang['userid_attr_name'] = 'User login name attribute';
 $lang['fullname_attr_name'] = 'Full name attribute';
 $lang['email_attr_name'] = 'E-mail attribute';
 $lang['groups_attr_name'] = 'Groups attribute';
-
-


### PR DESCRIPTION
This work implement the logoff of dokuwiki but not the SLO logoff.
The saml/adfs credentials are not revoked, so as soon as you try to re-login, your are.
- This commit mainly resolve annoying behaviour:  if authenticated via saml/adfs, we are not able to logoff and if we change the protocol from https to http, the process automatically send us to a wrong "http only" saml/adfs end point. As we should not login via http, saml/adfs should not be configured to answer and if so we receive an error message from the saml/idfs end point. In practice: 
1. Log In from dokuwiki (ok i am logged in)
2. go to dokuwiki with http: Direct error message from saml/adfs

Also:

- This implement the fallback for SLO (use-slo=) as this can be a desired behaviour
- and treat the case of a misconfiguration  (slo enpoint string is empty) 
- This is mainly a WIP on SLO, but even as such, the really annoying behaviour describe is resolved. As this improve the plugin, a pull request is submitted 
- There is a starting point to implement SLO, some comments and it incorporates a part of the work done by takuy and fschrempf as I think there is a good value on it