### PR TITLE
implement auto-login 

### DIFF
--- a/auth.php
+++ b/auth.php
@@ -57,7 +57,7 @@ class auth_plugin_adfs extends auth_plugin_authplain
         } else {
             $autoLoginConf = $this->getConf("auto_login");
             $autoLogin = ($autoLoginConf == "never") ? false : (
-                ($autoLoginConf == "after login" && get_doku_pref('adfs_autologin', 1)) || 
+                ($autoLoginConf == "after login" && get_doku_pref('adfs_autologin', 0)) || 
                 ($autoLoginConf == "always"));
         }
 

--- a/auth.php
+++ b/auth.php
@@ -39,6 +39,9 @@ class auth_plugin_adfs extends auth_plugin_authplain
         global $USERINFO;
         global $ID;
         global $ACT;
+
+        $autoLogin = false;
+        
         if (empty($ID)) $ID = getID();
 
         // trust session info, no need to recheck
@@ -51,9 +54,13 @@ class auth_plugin_adfs extends auth_plugin_authplain
             $USERINFO = $_SESSION[DOKU_COOKIE]['auth']['info'];
 
             return true;
-        }
+        } else {
+			$autoLogin = ($this->getConf("auto_login") == "never") ? false : (
+				($this->getConf("auto_login") == "after login" && get_doku_pref('adfs_autologin', 1)) || 
+				($this->getConf("auto_login") == "always"));
+		}
 
-        if (!isset($_POST['SAMLResponse']) && ($ACT == 'login' || get_doku_pref('adfs_autologin', 0))) {
+        if (!isset($_POST['SAMLResponse']) && ($ACT == 'login' || $autoLogin)) {
             // Initiate SAML auth request
             $url = $this->saml->login(
                 null, // returnTo: is configured in our settings

--- a/auth.php
+++ b/auth.php
@@ -41,7 +41,7 @@ class auth_plugin_adfs extends auth_plugin_authplain
         global $ACT;
 
         $autoLogin = false;
-        
+
         if (empty($ID)) $ID = getID();
 
         // trust session info, no need to recheck
@@ -55,9 +55,10 @@ class auth_plugin_adfs extends auth_plugin_authplain
 
             return true;
         } else {
-			$autoLogin = ($this->getConf("auto_login") == "never") ? false : (
-				($this->getConf("auto_login") == "after login" && get_doku_pref('adfs_autologin', 1)) || 
-				($this->getConf("auto_login") == "always"));
+            $autoLoginConf = $this->getConf("auto_login");
+			$autoLogin = ($autoLoginConf == "never") ? false : (
+				($autoLoginConf == "after login" && get_doku_pref('adfs_autologin', 1)) || 
+				($autoLoginConf == "always"));
 		}
 
         if (!isset($_POST['SAMLResponse']) && ($ACT == 'login' || $autoLogin)) {

--- a/auth.php
+++ b/auth.php
@@ -56,10 +56,10 @@ class auth_plugin_adfs extends auth_plugin_authplain
             return true;
         } else {
             $autoLoginConf = $this->getConf("auto_login");
-			$autoLogin = ($autoLoginConf == "never") ? false : (
-				($autoLoginConf == "after login" && get_doku_pref('adfs_autologin', 1)) || 
-				($autoLoginConf == "always"));
-		}
+            $autoLogin = ($autoLoginConf == "never") ? false : (
+                ($autoLoginConf == "after login" && get_doku_pref('adfs_autologin', 1)) || 
+                ($autoLoginConf == "always"));
+        }
 
         if (!isset($_POST['SAMLResponse']) && ($ACT == 'login' || $autoLogin)) {
             // Initiate SAML auth request

--- a/conf/default.php
+++ b/conf/default.php
@@ -8,6 +8,7 @@ $conf['endpoint']  = '';
 $conf['certificate'] = '';
 $conf['lowercase'] = 1;
 $conf['autoprovisioning'] = 1;
+$conf["auto_login"] = "never";
 $conf['userid_attr_name'] = 'login';
 $conf['fullname_attr_name'] = 'fullname';
 $conf['email_attr_name'] = 'email';

--- a/conf/metadata.php
+++ b/conf/metadata.php
@@ -8,6 +8,7 @@ $meta['endpoint']    = array('string');
 $meta['certificate'] = array('');
 $meta['lowercase']   = array('onoff');
 $meta['autoprovisioning'] = array('onoff');
+$meta["auto_login"] = array('multichoice','_choices' => array('never','after login','always'));
 $meta['userid_attr_name'] = array('string');
 $meta['fullname_attr_name'] = array('string');
 $meta['email_attr_name'] = array('string');

--- a/lang/en/settings.php
+++ b/lang/en/settings.php
@@ -8,6 +8,7 @@ $lang['endpoint']    = 'The SAML auth API endpoint. Usually <code>https://<i>&lt
 $lang['certificate'] = 'The SAML auth certificate';
 $lang['lowercase'] = 'Treat user and group names as case insensitive and lower case them automatically?';
 $lang['autoprovisioning'] = 'Automatic user provisioning: authenticated users are created automatically and do not need to be added manually by the wiki administrator';
+$lang["auto_login"] = "when to enforce auto-login: <code>never</code> will never ask to automatically authenticate; <code>after login</code> will prompt to automatically ask to re-authenticate if the DokuWiki session ends unless explicitly logged out; <code>always</code> will always require login";
 $lang['userid_attr_name'] = 'User login name attribute';
 $lang['fullname_attr_name'] = 'Full name attribute';
 $lang['email_attr_name'] = 'E-mail attribute';


### PR DESCRIPTION
adds a new config option: "auto_login" with three options for each use-case: `never`, `after login`, `always`

this would implement the ability to force auto-login (and resolve #8) with `always` but also give you control over how DokuWiki picks up SSO sessions. current behavior is that if DokuWiki session ends it will force you to log back in with SSO per `trustExternal` being called on each page view (`after login` now mimics this).

This PR changes behavior to `never` try to log back in by default (ie user has to press the Login button).

